### PR TITLE
Replaced var with stats::var in apply function to prevent failures

### DIFF
--- a/R/causalTree.R
+++ b/R/causalTree.R
@@ -168,7 +168,7 @@ causalTree <- function(formula, data, weights, treatment, subset,
 		}
 	}
 
-	xvar <- apply(X, 2, var)
+	xvar <- apply(X, 2, stats::var)
 	method <- "anova"
 	method.int <- 1
 


### PR DESCRIPTION
The causalTree function refers to a global variable "var" when computing variance (l.134), which can lead to a failure if "var" already exists in the global environment. 
I replaced var by stats::var to explicitly call the var function. 

Here's a reprex for the original issue. 
```
set.seed(123)
n <- 1000
df_sample <- data.frame(
  Y = rnorm(n, mean = 50, sd = 10) + 5 * rbinom(n, 1, 0.3),
  D = rbinom(n, 1, 0.5),
  X1 = rnorm(n, mean = 30, sd = 5),
  X2 = as.factor(sample(c("Male", "Female"), n, replace = TRUE))
)

var <- "some_variable"

causal_tree <- causalTree(
  formula = Y ~ X1 + X2,
  data = df_sample,
  treatment = df_sample$D,
  split.Rule = "CT"
)
```
leading to: 
```
> Error in get(as.character(FUN), mode = "function", envir = envir) : 
  object 'some_variable' of mode 'function' was not found
```



